### PR TITLE
Handle deleting a node when it is updated

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -45,7 +45,7 @@ var runCmd = &cobra.Command{
 		evict := controllers.NewEvictNodeController(k8Client, i.Core().V1().Nodes())
 		go evict.Run(doneCh)
 
-		delete := controllers.NewDeleteNodeController(k8Client, cloudClient, i.Core().V1().Pods())
+		delete := controllers.NewDeleteNodeController(k8Client, cloudClient, i.Core().V1().Pods(), i.Core().V1().Nodes())
 		go delete.Run(doneCh)
 
 		i.Start(doneCh)


### PR DESCRIPTION
A node could have no pods running when we send the eviction, in which case we need to delete it right away.